### PR TITLE
Don't pass in _config when registering app against UmbracoBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ To install
 
 In startup.cs under ConfigureServices add:
 
-`.AddMicrosoftAccountAuthentication(_config)`
+`.AddMicrosoftAccountAuthentication()`
 
 In the services.AddUmbraco bindings
 
 For example:
 ```
 var builder = services.AddUmbraco(_env, _config)
-    .AddBackOffice()
+	.AddBackOffice()
 	.AddWebsite()
 	.AddComposers()
-	.AddMicrosoftAccountAuthentication(_config)
+	.AddMicrosoftAccountAuthentication()
 	.AddAzureBlobMediaFileSystem();
 ```
 

--- a/src/Our.Umbraco.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
+++ b/src/Our.Umbraco.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Configuration;
@@ -12,10 +12,10 @@ namespace Our.Umbraco.AzureSSO
 {
 	public static class MicrosoftAccountAuthenticationExtensions
 	{
-		public static IUmbracoBuilder AddMicrosoftAccountAuthentication(this IUmbracoBuilder builder, IConfiguration configuration)
+		public static IUmbracoBuilder AddMicrosoftAccountAuthentication(this IUmbracoBuilder builder)
 		{
 			var azureSsoConfiguration = new AzureSSOConfiguration();
-			configuration.Bind("AzureSSO", azureSsoConfiguration);
+			builder.Config.Bind("AzureSSO", azureSsoConfiguration);
 
 			builder.Services.AddSingleton<AzureSsoSettings>(conf => new AzureSsoSettings(azureSsoConfiguration));
 			builder.Services.ConfigureOptions<MicrosoftAccountBackOfficeExternalLoginProviderOptions>();
@@ -28,14 +28,14 @@ namespace Our.Umbraco.AzureSSO
 					{
 						backOfficeAuthenticationBuilder.AddMicrosoftIdentityWebApp(options =>
 								{
-									configuration.Bind("AzureSSO:Credentials", options);
+									builder.Config.Bind("AzureSSO:Credentials", options);
 									options.SignInScheme = backOfficeAuthenticationBuilder.SchemeForBackOffice(MicrosoftAccountBackOfficeExternalLoginProviderOptions.SchemeName);
 									options.Events = new OpenIdConnectEvents();
 								},
-								options => { configuration.Bind("AzureSSO:Credentials", options); },
+								options => { builder.Config.Bind("AzureSSO:Credentials", options); },
 								displayName: azureSsoConfiguration.DisplayName ?? "Azure Active Directory",
 								openIdConnectScheme: backOfficeAuthenticationBuilder.SchemeForBackOffice(MicrosoftAccountBackOfficeExternalLoginProviderOptions.SchemeName) ?? String.Empty)
-							.EnableTokenAcquisitionToCallDownstreamApi(options => configuration.Bind("AzureSSO:Credentials", options), initialScopes)
+							.EnableTokenAcquisitionToCallDownstreamApi(options => builder.Config.Bind("AzureSSO:Credentials", options), initialScopes)
 							.AddInMemoryTokenCaches();
 
 


### PR DESCRIPTION
The `_config` is available on the `IUmbracoBuilder` as `builder.Config` so we can streamline the app registration slightly as we shouldn't need to pass it in.

Not sure if there was an intentional reason to pass the config in specifically - if so we could also make it optional?