### PR TITLE
Changed namespace of `AddMicrosoftAccountAuthentication()` extension method

### DIFF
--- a/src/Our.Umbraco.AzureSSO/AzureSSOConfiguration.cs
+++ b/src/Our.Umbraco.AzureSSO/AzureSSOConfiguration.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Our.Umbraco.AzureSSO
+{
+	public class AzureSSOConfiguration
+	{
+		public AzureSSOConfiguration()
+		{
+			GroupBindings = new Dictionary<string, string>();
+		}
+
+		public string? DisplayName { get; set; }
+
+		public string? ButtonStyle { get; set; }
+
+		public string? Icon { get; set; }
+
+		public Dictionary<string, string> GroupBindings { get; set; }
+
+		public bool? DenyLocalLogin { get; set; }
+	}
+}

--- a/src/Our.Umbraco.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
+++ b/src/Our.Umbraco.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,20 +42,6 @@ namespace Our.Umbraco.AzureSSO
 			});
 			return builder;
 		}
-		
+
 	}
-
-	public class AzureSSOConfiguration
-	{
-		public AzureSSOConfiguration()
-		{
-			GroupBindings = new Dictionary<string, string>();
-		}
-
-		public string? DisplayName { get; set; }
-		public string? ButtonStyle { get; set; }
-		public string? Icon { get; set; }
-		public Dictionary<string,string> GroupBindings { get; set; }
-		public bool? DenyLocalLogin { get; set; }
- 	}
 }

--- a/src/Our.Umbraco.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
+++ b/src/Our.Umbraco.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
@@ -3,11 +3,11 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Web;
+using Our.Umbraco.AzureSSO;
 using Our.Umbraco.AzureSSO.Settings;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Extensions;
 
-namespace Our.Umbraco.AzureSSO
+namespace Umbraco.Cms.Core.DependencyInjection
 {
 	public static class MicrosoftAccountAuthenticationExtensions
 	{
@@ -18,7 +18,7 @@ namespace Our.Umbraco.AzureSSO
 
 			builder.Services.AddSingleton<AzureSsoSettings>(conf => new AzureSsoSettings(azureSsoConfiguration));
 			builder.Services.ConfigureOptions<MicrosoftAccountBackOfficeExternalLoginProviderOptions>();
-			
+
 			var initialScopes = new string[] { };
 			builder.AddBackOfficeExternalLogins(logins =>
 			{


### PR DESCRIPTION
Following my comment, https://github.com/Gibe/Our.Umbraco.AzureSSO/commit/07b181d12d77e524b74556a5b47561b17c734f6a#r98069150, I've changed namespace of `AddMicrosoftAccountAuthentication()` extension method to match `IUmbracoBuilder`, with a view to make it more developer friendly, e.g. in terms of (intellisense) discovery and reducing the `using` references at the top.

I appreciate this may feel quite opinionated and counter-intuitive at first. Hopefully it'll make sense.

Alternatively, the "Umbraco.Extensions" namespace could also be used, as that it included with Umbraco's `global usings` (referenced in their NuGet package).