### PR TITLE
Group enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ To configure add the following section to the root of your appsettings.json file
     "GroupBindings": {
         "<AD group>": "<umbraco group>",
         "<another AD group>": "<umbraco group>"
-    }
+    },
+    "SetGroupsOnLogin": true,
+    "DefaultGroups": [
+		"editors"
+	],
+    "Icon": "fa fa-lock",
+    "ButtonStyle": "btn-microsoft",
 },
 ```
 
@@ -54,11 +60,15 @@ You'll need to configure these settings based on the values in Azure:
 
 You can also customise the configuration by setting these settings:
 
-| Setting          | Description                                           |
-| ---------------- | ----------------------------------------------------- |
-| DisplayName      | The display name for use on the login button          |
-| DenyLocalLogin   | Allow users to login via Umbraco's standard login     |
-| GroupBindings    | The bindings for AD group to Umbraco group            |
+| Setting          | Description                                                                                  |
+| ---------------- | -------------------------------------------------------------------------------------------- |
+| DisplayName      | The display name for use on the login button                                                 |
+| DenyLocalLogin   | Allow users to login via Umbraco's standard login                                            |
+| GroupBindings    | The bindings for AD group to Umbraco group                                                   |
+| SetGroupsOnLogin | Whether or not to reset the users assigned groups on each login                              |
+| DefaultGroups    | The groups to assign to users regardless of any AD groups assigned (defaults to none)        |
+| Icon             | The icon to use on the login button                                                          |
+| ButtonStyle      | The style to use on the login button                                                         |
 
 ## Group Bindings
 

--- a/src/Umbraco.Community.AzureSSO/AzureSSOConfiguration.cs
+++ b/src/Umbraco.Community.AzureSSO/AzureSSOConfiguration.cs
@@ -17,6 +17,10 @@ namespace Umbraco.Community.AzureSSO
 
 		public Dictionary<string, string> GroupBindings { get; set; }
 
+		public bool? SetGroupsOnLogin { get; set; }
+
+		public string[]? DefaultGroups { get; set; }
+
 		public bool? DenyLocalLogin { get; set; }
 	}
 }

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
@@ -60,7 +60,10 @@ namespace Umbraco.Community.AzureSSO
 				OnAutoLinking = SetGroups,
 				OnExternalLogin = (user, loginInfo) =>
 				{
-					if (_settings.SetGroupsOnLogin) SetGroups(user, loginInfo);
+					if (_settings.SetGroupsOnLogin) 
+		 			{
+						SetGroups(user, loginInfo);
+					}
 
 					return true; //returns a boolean indicating if sign in should continue or not.
 				}

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
-using Microsoft.Identity.Web;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Web.BackOffice.Security;
 using Umbraco.Community.AzureSSO.Settings;
@@ -61,7 +60,7 @@ namespace Umbraco.Community.AzureSSO
 				OnAutoLinking = SetGroups,
 				OnExternalLogin = (user, loginInfo) =>
 				{
-					SetGroups(user, loginInfo);
+					if (_settings.SetGroupsOnLogin) SetGroups(user, loginInfo);
 
 					return true; //returns a boolean indicating if sign in should continue or not.
 				}
@@ -89,6 +88,11 @@ namespace Umbraco.Community.AzureSSO
 				user.AddRole(_settings.GroupLookup[group.Value]);
 			}
 
+			foreach (var group in _settings.DefaultGroups)
+			{
+				user.AddRole(group);
+			}
+
 			if (loginInfo.Principal?.Identity?.Name != null)
 			{
 				user.Name = DisplayName(loginInfo.Principal, defaultValue: loginInfo.Principal.Identity.Name);
@@ -101,7 +105,7 @@ namespace Umbraco.Community.AzureSSO
 		{
 			var displayName = claimsPrincipal.FindFirstValue("name");
 
-			return !string.IsNullOrWhiteSpace(displayName) ? displayName: defaultValue;
+			return !string.IsNullOrWhiteSpace(displayName) ? displayName : defaultValue;
 		}
 	}
 }

--- a/src/Umbraco.Community.AzureSSO/Settings/AzureSSOSettings.cs
+++ b/src/Umbraco.Community.AzureSSO/Settings/AzureSSOSettings.cs
@@ -14,6 +14,8 @@ namespace Umbraco.Community.AzureSSO.Settings
 		public string ButtonStyle => _configuration.ButtonStyle ?? "btn-microsoft";
 		public string Icon => _configuration.Icon ?? "fa fa-lock";
 		public Dictionary<string, string> GroupLookup => _configuration.GroupBindings;
+		public bool SetGroupsOnLogin => _configuration.SetGroupsOnLogin ?? true;
+		public string[] DefaultGroups => _configuration.DefaultGroups ?? new string[] { };
 		public bool DenyLocalLogin => _configuration.DenyLocalLogin ?? false;
 	}
 }


### PR DESCRIPTION
I was using this on a project where the client didn't want to assign groups using groups in their AD, so I needed a way to prevent the resetting of groups on each login, and setting one or more default groups for each user.

I've added a few config options for setting this. If you change `SetGroupsOnLogin` to be false, it won't run the `SetGroups` method on each login.

In addition, I've added a string array of `DefaultGroups`, so you can assign eg. editor to all new users. These groups are assigned in the `SetGroups` method.

Also, I've added docs about the option to control the icon and style of the login button.