### PR TITLE
Add `AutoRedirectLoginToExternalProvider` from appsetting configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,16 @@ You'll need to configure these settings based on the values in Azure:
 
 You can also customise the configuration by setting these settings:
 
-| Setting          | Description                                                                                  |
-| ---------------- | -------------------------------------------------------------------------------------------- |
-| DisplayName      | The display name for use on the login button                                                 |
-| Icon             | The class name for the icon to use                                                           |
-| ButtonStyle      | The class name for the button style                                                          |
-| AutoRedirectLoginToExternalProvider   | Automatically redirect to the external login provider                                            |
-| DenyLocalLogin   | Allow users to login via Umbraco's standard login                                            |
-| GroupBindings    | The bindings for AD group to Umbraco group                                                   |
-| SetGroupsOnLogin | Whether or not to reset the users assigned groups on each login                              |
-| DefaultGroups    | The groups to assign to users regardless of any AD groups assigned (defaults to none)        |
+| Setting          			| Description                                                                                  |
+| ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| DisplayName      			| The display name for use on the login button                                                 |
+| Icon             			| The class name for the icon to use                                                           |
+| ButtonStyle      			| The class name for the button style                                                          |
+| AutoRedirectLoginToExternalProvider   | Automatically redirect to the external login provider                                        |
+| DenyLocalLogin   			| Allow users to login via Umbraco's standard login                                            |
+| GroupBindings    			| The bindings for AD group to Umbraco group                                                   |
+| SetGroupsOnLogin 			| Whether or not to reset the users assigned groups on each login                              |
+| DefaultGroups    			| The groups to assign to users regardless of any AD groups assigned (defaults to none)        |
 
 ## ButtonStyle
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ To configure add the following section to the root of your appsettings.json file
     },
     "DisplayName": "Azure AD",
     "DenyLocalLogin": true,
+    "AutoRedirectLoginToExternalProvider": true,
     "GroupBindings": {
         "<AD group>": "<umbraco group>",
         "<another AD group>": "<umbraco group>"
     },
     "SetGroupsOnLogin": true,
     "DefaultGroups": [
-		"editors"
+		"editor"
 	],
     "Icon": "fa fa-lock",
     "ButtonStyle": "btn-microsoft",
@@ -65,6 +66,7 @@ You can also customise the configuration by setting these settings:
 | DisplayName      | The display name for use on the login button                                                 |
 | Icon             | The class name for the icon to use                                                           |
 | ButtonStyle      | The class name for the button style                                                          |
+| AutoRedirectLoginToExternalProvider   | Automatically redirect to the external login provider                                            |
 | DenyLocalLogin   | Allow users to login via Umbraco's standard login                                            |
 | GroupBindings    | The bindings for AD group to Umbraco group                                                   |
 | SetGroupsOnLogin | Whether or not to reset the users assigned groups on each login                              |

--- a/src/Umbraco.Community.AzureSSO/AzureSSOConfiguration.cs
+++ b/src/Umbraco.Community.AzureSSO/AzureSSOConfiguration.cs
@@ -4,6 +4,9 @@ namespace Umbraco.Community.AzureSSO
 {
 	public class AzureSSOConfiguration
 	{
+		public const string AzureSsoSectionName = "AzureSSO";
+		public const string AzureSsoCredentialSectionName = "AzureSSO:Credentials";
+
 		public AzureSSOConfiguration()
 		{
 			GroupBindings = new Dictionary<string, string>();
@@ -22,5 +25,7 @@ namespace Umbraco.Community.AzureSSO
 		public string[]? DefaultGroups { get; set; }
 
 		public bool? DenyLocalLogin { get; set; }
+
+		public bool? AutoRedirectLoginToExternalProvider { get; set; }
 	}
 }

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
@@ -14,12 +14,12 @@ namespace Umbraco.Cms.Core.DependencyInjection
 		public static IUmbracoBuilder AddMicrosoftAccountAuthentication(this IUmbracoBuilder builder)
 		{
 			var azureSsoConfiguration = new AzureSSOConfiguration();
-			builder.Config.Bind("AzureSSO", azureSsoConfiguration);
+			builder.Config.Bind(AzureSSOConfiguration.AzureSsoSectionName, azureSsoConfiguration);
 
 			builder.Services.AddSingleton<AzureSsoSettings>(conf => new AzureSsoSettings(azureSsoConfiguration));
 			builder.Services.ConfigureOptions<MicrosoftAccountBackOfficeExternalLoginProviderOptions>();
 			
-			var initialScopes = new string[] { };
+			var initialScopes = Array.Empty<string>();
 			builder.AddBackOfficeExternalLogins(logins =>
 			{
 				logins.AddBackOfficeLogin(
@@ -27,14 +27,14 @@ namespace Umbraco.Cms.Core.DependencyInjection
 					{
 						backOfficeAuthenticationBuilder.AddMicrosoftIdentityWebApp(options =>
 								{
-									builder.Config.Bind("AzureSSO:Credentials", options);
+									builder.Config.Bind(AzureSSOConfiguration.AzureSsoCredentialSectionName, options);
 									options.SignInScheme = backOfficeAuthenticationBuilder.SchemeForBackOffice(MicrosoftAccountBackOfficeExternalLoginProviderOptions.SchemeName);
 									options.Events = new OpenIdConnectEvents();
 								},
-								options => { builder.Config.Bind("AzureSSO:Credentials", options); },
+								options => { builder.Config.Bind(AzureSSOConfiguration.AzureSsoCredentialSectionName, options); },
 								displayName: azureSsoConfiguration.DisplayName ?? "Azure Active Directory",
 								openIdConnectScheme: backOfficeAuthenticationBuilder.SchemeForBackOffice(MicrosoftAccountBackOfficeExternalLoginProviderOptions.SchemeName) ?? String.Empty)
-							.EnableTokenAcquisitionToCallDownstreamApi(options => builder.Config.Bind("AzureSSO:Credentials", options), initialScopes)
+							.EnableTokenAcquisitionToCallDownstreamApi(options => builder.Config.Bind(AzureSSOConfiguration.AzureSsoCredentialSectionName, options), initialScopes)
 							.AddInMemoryTokenCaches();
 
 

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Web.BackOffice.Security;
 using Umbraco.Community.AzureSSO.Settings;
@@ -19,9 +20,9 @@ namespace Umbraco.Community.AzureSSO
 			_settings = settings;
 		}
 
-		public void Configure(string name, BackOfficeExternalLoginProviderOptions options)
+		public void Configure(string? name, BackOfficeExternalLoginProviderOptions options)
 		{
-			if (name != "Umbraco." + SchemeName)
+			if (name != $"{Constants.Security.BackOfficeExternalAuthenticationTypePrefix}{SchemeName}")
 			{
 				return;
 			}
@@ -40,7 +41,7 @@ namespace Umbraco.Community.AzureSSO
 					// Optionally specify default user group, else
 					// assign in the OnAutoLinking callback
 					// (default is editor)
-					defaultUserGroups: new string[] { },
+					defaultUserGroups: System.Array.Empty<string>(),
 
 					// Optionally specify the default culture to create
 					// the user as. If null it will use the default
@@ -77,8 +78,8 @@ namespace Umbraco.Community.AzureSSO
 
 			// Optionally choose to automatically redirect to the
 			// external login provider so the user doesn't have
-			// to click the login button. This is
-			options.AutoRedirectLoginToExternalProvider = false;
+			// to click the login button.
+			options.AutoRedirectLoginToExternalProvider = _settings.AutoRedirectLoginToExternalProvider; ;
 		}
 
 		private void SetGroups(BackOfficeIdentityUser user, ExternalLoginInfo loginInfo)

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
@@ -79,7 +79,7 @@ namespace Umbraco.Community.AzureSSO
 			// Optionally choose to automatically redirect to the
 			// external login provider so the user doesn't have
 			// to click the login button.
-			options.AutoRedirectLoginToExternalProvider = _settings.AutoRedirectLoginToExternalProvider; ;
+			options.AutoRedirectLoginToExternalProvider = _settings.AutoRedirectLoginToExternalProvider;
 		}
 
 		private void SetGroups(BackOfficeIdentityUser user, ExternalLoginInfo loginInfo)

--- a/src/Umbraco.Community.AzureSSO/Settings/AzureSSOSettings.cs
+++ b/src/Umbraco.Community.AzureSSO/Settings/AzureSSOSettings.cs
@@ -15,7 +15,8 @@ namespace Umbraco.Community.AzureSSO.Settings
 		public string Icon => _configuration.Icon ?? "fa fa-lock";
 		public Dictionary<string, string> GroupLookup => _configuration.GroupBindings;
 		public bool SetGroupsOnLogin => _configuration.SetGroupsOnLogin ?? true;
-		public string[] DefaultGroups => _configuration.DefaultGroups ?? new string[] { };
+		public string[] DefaultGroups => _configuration.DefaultGroups ?? System.Array.Empty<string>();
 		public bool DenyLocalLogin => _configuration.DenyLocalLogin ?? false;
+		public bool AutoRedirectLoginToExternalProvider => _configuration.AutoRedirectLoginToExternalProvider ?? false;
 	}
 }

--- a/src/Umbraco.Community.AzureSSO/appsettings-schema.UmbracoCommunityAzureSSO.json
+++ b/src/Umbraco.Community.AzureSSO/appsettings-schema.UmbracoCommunityAzureSSO.json
@@ -61,6 +61,10 @@
 					"type": "boolean",
 					"description": "Allow users to login via Umbraco's standard login"
 				},
+				"AutoRedirectLoginToExternalProvider": {
+					"type": "boolean",
+					"description": "Automatically redirect to the external login provider"
+				},
 				"SetGroupsOnLogin": {
 					"type": "boolean",
 					"description": "The bindings for AD group to Umbraco group."


### PR DESCRIPTION
remove a couple of magic strings eg `Constants.Security.BackOfficeExternalAuthenticationTypePrefix`
correct the readme defaultgroup to `editor`
optimisation `Array.Empty<string>()` over `new string [] {}`
align nullability of reference type `public void Configure(string? name ...)`