### PR TITLE
detatch Sync UserName from azureAD from the SetGroupsOnLogin flag.

### DIFF
--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
@@ -57,13 +57,18 @@ namespace Umbraco.Community.AzureSSO
 			)
 			{
 				// Optional callback
-				OnAutoLinking = SetGroups,
+				OnAutoLinking = (autoLoginUser, loginInfo) =>
+				{
+					SetGroups(autoLoginUser, loginInfo);
+					SetName(autoLoginUser, loginInfo);
+				},
 				OnExternalLogin = (user, loginInfo) =>
 				{
-					if (_settings.SetGroupsOnLogin) 
-		 			{
+					if (_settings.SetGroupsOnLogin)
+					{
 						SetGroups(user, loginInfo);
 					}
+					SetName(user, loginInfo);
 
 					return true; //returns a boolean indicating if sign in should continue or not.
 				}
@@ -95,7 +100,10 @@ namespace Umbraco.Community.AzureSSO
 			{
 				user.AddRole(group);
 			}
+		}
 
+		private void SetName(BackOfficeIdentityUser user, ExternalLoginInfo loginInfo)
+		{
 			if (loginInfo.Principal?.Identity?.Name != null)
 			{
 				user.Name = DisplayName(loginInfo.Principal, defaultValue: loginInfo.Principal.Identity.Name);


### PR DESCRIPTION
Might just be a naming issue, eg `SetGroupsOnLogin` might be intended to be `SyncDataOnLogin` but if not then groups sync shouldn't stop the name synching??

Might also want to have a  flag for nameSynching?