### PR TITLE
Add support for csv values for the umbraco user group aliases when mapping groups

### DIFF
--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
@@ -88,7 +88,11 @@ namespace Umbraco.Community.AzureSSO
 			var groups = loginInfo.Principal.Claims.Where(c => _settings.GroupLookup.ContainsKey(c.Value));
 			foreach (var group in groups)
 			{
-				user.AddRole(_settings.GroupLookup[group.Value]);
+				var umbracoGroups = _settings.GroupLookup[group.Value].Split(',');
+				foreach (var umbracoGroupAlias in umbracoGroups)
+				{
+					user.AddRole(umbracoGroupAlias);
+				}
 			}
 
 			foreach (var group in _settings.DefaultGroups)


### PR DESCRIPTION
This is especially useful for sensitive data e.g.

`"xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx": "admin,sensitiveData"`