### PR TITLE
Allow changing of token cache type

### DIFF
--- a/src/Umbraco.Community.AzureSSO/AzureSSOConfiguration.cs
+++ b/src/Umbraco.Community.AzureSSO/AzureSSOConfiguration.cs
@@ -22,5 +22,7 @@ namespace Umbraco.Community.AzureSSO
 		public string[]? DefaultGroups { get; set; }
 
 		public bool? DenyLocalLogin { get; set; }
+
+		public TokenCacheType TokenCacheType { get; set; } = TokenCacheType.InMemory;
 	}
 }

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
@@ -35,13 +35,33 @@ namespace Umbraco.Cms.Core.DependencyInjection
 								displayName: azureSsoConfiguration.DisplayName ?? "Azure Active Directory",
 								openIdConnectScheme: backOfficeAuthenticationBuilder.SchemeForBackOffice(MicrosoftAccountBackOfficeExternalLoginProviderOptions.SchemeName) ?? String.Empty)
 							.EnableTokenAcquisitionToCallDownstreamApi(options => builder.Config.Bind("AzureSSO:Credentials", options), initialScopes)
-							.AddInMemoryTokenCaches();
-
-
+							.AddDistributedTokenCaches()
+							.AddTokenCaches(azureSsoConfiguration.TokenCacheType);
 					});
 			});
 			return builder;
 		}
-		
+
+		private static MicrosoftIdentityAppCallsWebApiAuthenticationBuilder AddTokenCaches(this MicrosoftIdentityAppCallsWebApiAuthenticationBuilder builder, TokenCacheType tokenCacheType)
+		{
+			switch (tokenCacheType)
+			{
+				case TokenCacheType.InMemory:
+					builder.AddInMemoryTokenCaches();
+					break;
+				case TokenCacheType.Session:
+					builder.AddSessionTokenCaches();
+					break;
+				case TokenCacheType.Distributed:
+					builder.AddDistributedTokenCaches();
+					break;
+				default:
+					builder.AddInMemoryTokenCaches();
+					break;
+			}
+
+			return builder;
+		}
+
 	}
 }

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
@@ -35,7 +35,6 @@ namespace Umbraco.Cms.Core.DependencyInjection
 								displayName: azureSsoConfiguration.DisplayName ?? "Azure Active Directory",
 								openIdConnectScheme: backOfficeAuthenticationBuilder.SchemeForBackOffice(MicrosoftAccountBackOfficeExternalLoginProviderOptions.SchemeName) ?? String.Empty)
 							.EnableTokenAcquisitionToCallDownstreamApi(options => builder.Config.Bind("AzureSSO:Credentials", options), initialScopes)
-							.AddDistributedTokenCaches()
 							.AddTokenCaches(azureSsoConfiguration.TokenCacheType);
 					});
 			});

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountBackOfficeExternalLoginProviderOptions.cs
@@ -88,7 +88,11 @@ namespace Umbraco.Community.AzureSSO
 			var groups = loginInfo.Principal.Claims.Where(c => _settings.GroupLookup.ContainsKey(c.Value));
 			foreach (var group in groups)
 			{
-				user.AddRole(_settings.GroupLookup[group.Value]);
+				var umbracoGroups = _settings.GroupLookup[group.Value].Split(',');
+				foreach (var umbracoGroupAlias in umbracoGroups)
+				{
+					user.AddRole(umbracoGroupAlias);
+				}
 			}
 
 			foreach (var group in _settings.DefaultGroups)

--- a/src/Umbraco.Community.AzureSSO/Settings/AzureSSOSettings.cs
+++ b/src/Umbraco.Community.AzureSSO/Settings/AzureSSOSettings.cs
@@ -17,5 +17,7 @@ namespace Umbraco.Community.AzureSSO.Settings
 		public bool SetGroupsOnLogin => _configuration.SetGroupsOnLogin ?? true;
 		public string[] DefaultGroups => _configuration.DefaultGroups ?? new string[] { };
 		public bool DenyLocalLogin => _configuration.DenyLocalLogin ?? false;
+		public TokenCacheType TokenCacheType => _configuration.TokenCacheType;
+
 	}
 }

--- a/src/Umbraco.Community.AzureSSO/TokenCacheType.cs
+++ b/src/Umbraco.Community.AzureSSO/TokenCacheType.cs
@@ -1,0 +1,9 @@
+﻿namespace Umbraco.Community.AzureSSO
+{
+	public enum TokenCacheType
+	{
+		InMemory = 0,
+		Session = 1,
+		Distributed =2
+	}
+}

--- a/src/Umbraco.Community.AzureSSO/appsettings-schema.UmbracoCommunityAzureSSO.json
+++ b/src/Umbraco.Community.AzureSSO/appsettings-schema.UmbracoCommunityAzureSSO.json
@@ -85,12 +85,36 @@
 							"type": "string"
 						}
 					]
+				},
+				"TokenCacheType": {
+					"description": "The token cache type to use",
+					"default": "Unknown",
+					"oneOf": [
+						{
+							"$ref": "#/definitions/TokenCacheType"
+						}
+					]
 				}
 			},
 			"required": [
 				"Credentials"
 			]
+		},
+		"TokenCacheType": {
+			"type": "string",
+			"description": "Represents the type of token cache to use",
+			"x-enumNames": [
+				"InMemory",
+				"Session",
+				"Distributed"
+			],
+			"enum": [
+				"InMemory",
+				"Session",
+				"Distributed"
+			]
 		}
+
 	},
 	"required": [
 		"AzureSSO"


### PR DESCRIPTION
Allows switching from In Memory to Session or Distributed, does not set up those providers though.
For example, if using Session then 
`app.UseSession()` would need to be added to startup.cs at the start of the Configure method

Should resolve [17](https://github.com/Gibe/Umbraco.Community.AzureSSO/issues/17)