### PR TITLE
Hotfix/add disablecomposer option

### DIFF
--- a/src/Umbraco.Community.AzureSSO/AzureSSOComposer.cs
+++ b/src/Umbraco.Community.AzureSSO/AzureSSOComposer.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 
@@ -7,7 +8,11 @@ namespace Umbraco.Community.AzureSSO
 	{
 		public void Compose(IUmbracoBuilder builder)
 		{
-			builder.AddMicrosoftAccountAuthentication();
+			var disableComposer = builder.Config.GetSection(AzureSSOConfiguration.AzureSsoSectionName).GetValue<bool>("DisableComposer");
+			if (!disableComposer)
+			{
+				builder.AddMicrosoftAccountAuthenticationInternal();
+			}
 		}
 	}
 }

--- a/src/Umbraco.Community.AzureSSO/AzureSSOConfiguration.cs
+++ b/src/Umbraco.Community.AzureSSO/AzureSSOConfiguration.cs
@@ -32,6 +32,7 @@ namespace Umbraco.Community.AzureSSO
 		public AzureSSOCredentials? Credentials { get; set; }
 
 		public AzureSSOConfiguration[]? Profiles { get; set; }
+		public bool DisableComposer { get; set; } = false;
 
 		public bool IsValid()
 		{

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
@@ -12,10 +12,11 @@ namespace Umbraco.Community.AzureSSO
 {
 	public static class MicrosoftAccountAuthenticationExtensions
 	{
-		internal static IUmbracoBuilder AddMicrosoftAccountAuthentication(this IUmbracoBuilder builder)
+		internal static IUmbracoBuilder AddMicrosoftAccountAuthenticationInternal(this IUmbracoBuilder builder)
 		{
 			var azureSsoConfiguration = new AzureSSOConfiguration();
 			builder.Config.Bind(AzureSSOConfiguration.AzureSsoSectionName, azureSsoConfiguration);
+
 			builder.Services.AddSingleton<AzureSSOConfiguration>(conf => azureSsoConfiguration);
 			
 			var settings = new AzureSsoSettings(azureSsoConfiguration);
@@ -54,6 +55,13 @@ namespace Umbraco.Community.AzureSSO
 			return builder;
 		}
 
+		public static IUmbracoBuilder AddMicrosoftAccountAuthentication(this IUmbracoBuilder builder)
+		{
+			var disableComposer = builder.Config.GetSection(AzureSSOConfiguration.AzureSsoSectionName).GetValue<bool>("DisableComposer");
+
+			// if composer is enabled don't add
+			return disableComposer ? builder.AddMicrosoftAccountAuthenticationInternal() : builder;
+		}
 		private static void CopyCredentials(MicrosoftIdentityOptions options, AzureSsoCredentialSettings settings)
 		{
 			options.Instance = settings.Instance;

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
@@ -16,7 +16,6 @@ namespace Umbraco.Community.AzureSSO
 		{
 			var azureSsoConfiguration = new AzureSSOConfiguration();
 			builder.Config.Bind(AzureSSOConfiguration.AzureSsoSectionName, azureSsoConfiguration);
-
 			builder.Services.AddSingleton<AzureSSOConfiguration>(conf => azureSsoConfiguration);
 			
 			var settings = new AzureSsoSettings(azureSsoConfiguration);

--- a/src/Umbraco.Community.AzureSSO/appsettings-schema.UmbracoCommunityAzureSSO.json
+++ b/src/Umbraco.Community.AzureSSO/appsettings-schema.UmbracoCommunityAzureSSO.json
@@ -115,6 +115,10 @@
 							"$ref": "#/definitions/TokenCacheType"
 						}
 					]
+				},
+				"DisableComposer": {
+					"type": "boolean",
+					"description": "Disable the Umbraco composer, AddMicrosoftAccountAuthentication will need to be called from Program.cs"
 				}
 			},
 			"required": [


### PR DESCRIPTION
## Describe your changes

Add option to disable the Umbraco composer if you wish to register in Program.cs instead. I have added safety checks so that if both AddMicrosoftAccountAuthentication is in Program.cs and the Composer is enabled only the Composer executes.

## Link to issue

https://github.com/Gibe/Umbraco.Community.AzureSSO/issues/37

## Checklist before requesting a review

- [x] I have performed a self-review of my code

