### PR TITLE
Add extension manifests so that buttons render in v14/15

### DIFF
--- a/src/Umbraco.Community.AzureSSO/AzureSSOManifestReader.cs
+++ b/src/Umbraco.Community.AzureSSO/AzureSSOManifestReader.cs
@@ -1,0 +1,78 @@
+#if NEW_BACKOFFICE
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Infrastructure.Manifest;
+using Umbraco.Community.AzureSSO.Settings;
+
+namespace Umbraco.Community.AzureSSO
+{
+	public class AzureSsoManifestReader(AzureSsoSettings azureSsoSettings) : IPackageManifestReader
+	{
+		public async Task<IEnumerable<PackageManifest>> ReadPackageManifestsAsync()
+		{
+			return await Task.Run(() =>
+			{
+				var extensions = new List<JsonObject>();
+
+				foreach (var profile in azureSsoSettings.Profiles)
+				{
+					var look = "primary";
+					var color = "default";
+
+					if (profile.ButtonStyle.Contains('-') && profile.ButtonStyle != "btn-microsoft")
+					{
+						var buttonStyle = profile.ButtonStyle.Split('-');
+						look = buttonStyle[0];
+						color = buttonStyle[1];
+					} else if (profile.ButtonStyle != "btn-microsoft")
+					{
+						look = profile.ButtonStyle;
+					}
+
+					var meta = new JsonObject
+					{
+						["label"] = profile.DisplayName,
+						["defaultView"] = new JsonObject
+						{
+							["icon"] = profile.Icon,
+							["look"] = look,
+							["color"] = color
+						},
+						["behavior"] = new JsonObject
+						{
+							["autoRedirect"] = profile.AutoRedirectLoginToExternalProvider
+						},
+						["linking"] = new JsonObject
+						{
+							["allowManualLinking"] = false
+						}
+					};
+
+					var extension = new JsonObject
+					{
+						["name"] = "Umbraco.Community.AzureSSO" + profile.Name,
+						["alias"] = "Umbraco.Community.AzureSSO" + profile.Name.Replace(" ", ""),
+						["type"] = "authProvider",
+						["forProviderName"] = profile.Name,
+						["meta"] = meta
+					};
+
+					extensions.Add(extension);
+				}
+
+				return new List<PackageManifest>() {
+					new PackageManifest()
+					{
+						AllowTelemetry = true,
+						Name = "Umbraco Community AzureSSO",
+						Extensions = [.. extensions],
+						AllowPublicAccess = true
+					}
+				};
+			});
+		}
+	}
+}
+#endif

--- a/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
+++ b/src/Umbraco.Community.AzureSSO/MicrosoftAccountAuthenticationExtensions.cs
@@ -5,11 +5,15 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Web;
 using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Web.BackOffice.Security;
 using Umbraco.Community.AzureSSO.Settings;
 using Umbraco.Extensions;
+
 #if NEW_BACKOFFICE
 using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Infrastructure.Manifest;
+#endif
+#if OLD_BACKOFFICE
+using Umbraco.Cms.Web.BackOffice.Security;
 #endif
 
 namespace Umbraco.Community.AzureSSO
@@ -26,6 +30,9 @@ namespace Umbraco.Community.AzureSSO
 			builder.Services.AddSingleton<AzureSsoSettings>(conf => settings);
 			builder.Services.ConfigureOptions<MicrosoftAccountBackOfficeExternalLoginProviderOptions>();
 
+#if NEW_BACKOFFICE
+			builder.Services.AddSingleton<IPackageManifestReader, AzureSsoManifestReader>();
+#endif
 			var initialScopes = Array.Empty<string>();
 			builder.AddBackOfficeExternalLogins(logins =>
 				{

--- a/src/Umbraco.Community.AzureSSO/Umbraco.Community.AzureSSO.csproj
+++ b/src/Umbraco.Community.AzureSSO/Umbraco.Community.AzureSSO.csproj
@@ -39,6 +39,9 @@
 		<PackageReference Include="Umbraco.Cms.Api.Management">
 			<Version>15.0.0</Version>
 		</PackageReference>
+		<PackageReference Include="Umbraco.Cms.Infrastructure">
+			<Version>15.0.0</Version>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' And !$(Configuration.Contains('13'))">
 		<PackageReference Include="Umbraco.Cms.Web.Common">

--- a/src/Umbraco.Community.AzureSSO/Umbraco.Community.AzureSSO.csproj
+++ b/src/Umbraco.Community.AzureSSO/Umbraco.Community.AzureSSO.csproj
@@ -50,6 +50,9 @@
 		<PackageReference Include="Umbraco.Cms.Api.Management">
 			<Version>14.0.0</Version>
 		</PackageReference>
+		<PackageReference Include="Umbraco.Cms.Infrastructure">
+			<Version>14.0.0</Version>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' And $(Configuration.Contains('13'))">
 		<PackageReference Include="Umbraco.Cms.Web.BackOffice">


### PR DESCRIPTION
Implemented a C# manifest with extensions generated from SSO profiles so that buttons render.

Implemented a split on the ButtonStyle for compatibility with older versions for "look-color", so values should be "primary-danger" or "primary-positive", see https://uui.umbraco.com/?path=/story/uui-button--looks-and-colors. Made the default "primary-default"

Icon should use the Umbraco Icon pricker or custom registered e.g. "icon-cloudy"

Tested on v15